### PR TITLE
Add netstandard2.0 target.

### DIFF
--- a/src/Bijection/Bijection.csproj
+++ b/src/Bijection/Bijection.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard1.0;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 


### PR DESCRIPTION
Hello!

According to [this document](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting), Microsoft's current recommendation is to always include a netstandard2.0 target, even if a netstandard1.x target is still present/required.

> DO include a netstandard2.0 target if you require a netstandard1.x target. All platforms supporting .NET Standard 2.0 will use the netstandard2.0 target and benefit from having a smaller package graph while older platforms will still work and fall back to using the netstandard1.x target.

Targeting netstandard2.0 will simplify the dependency graph.

This pull request adds a netstandard2.0 target.

Thanks!